### PR TITLE
Add retry clause for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are other accessories but this was only tested with these three devices:
 ## Installation
 
 ```
-pip install sengled-client
+pip3 install sengled-client
 ```
 
 ## Usage
@@ -31,8 +31,11 @@ api = sengled.api(
     # starts and reduce the number of logins.
     session_path="/tmp/sengled.pickle",
 
-    # Prints details of the api request/responses when True, defaults to false.
+    # Prints details of the api request/responses when True, defaults to False.
     debug=True
+
+    # Retries login if no server response when True, defaults to False. (Max retry number is 100)
+    retry=True
 )
 ```
 

--- a/sengled/__init__.py
+++ b/sengled/__init__.py
@@ -17,10 +17,12 @@ def api_from_env():
     * SENGLED_PASSWORD
     * SENGLED_SESSION_PATH (optional)
     * SENGLED_DEBUG (optional, default: False)
+    * SENGLED_RETRY (optional, default: False)
     """
     return api(
         username     = os.environ["SENGLED_USERNAME"],
         password     = os.environ["SENGLED_PASSWORD"],
         session_path = os.environ.get("SENGLED_SESSION_PATH"),
         debug        = os.environ.get("SENGLED_DEBUG", "false").lower() in ["true", "1", "yes", "t"],
+        retry        = os.environ.get("SENGLED_RETRY", "false").lower() in ["true", "1", "yes", "t"]
     )


### PR DESCRIPTION
## Problem/Proposed fix

I found that, due to Sengled's flaky servers, the login command would often fail with the message: `{'ret': -1, 'msg': 'System error', 'gret': 0, 'serverVersionMin': '3', 'serverVersionNow': '3'}`

This can be frustrating, especially as it is not a problem with this API itself.

The proposed fix repeats the login request if the relevant flag is present until it either succeeds or surpasses the specific maximum value (we do not want it to get stuck in an infinite loop). 